### PR TITLE
[Dashboard] Extends thumbnail hit zones for a11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-router-redux": "^4.0.8",
     "react-scripts": "1.1.0",
     "redux": "^3.7.2",
-    "redux-devtools-extension": "^2.13.2"
+    "redux-devtools-extension": "^2.13.2",
+    "redux-form": "^7.4.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/List/ListItems.js
+++ b/src/components/List/ListItems.js
@@ -19,18 +19,18 @@ const styles = {
     margin: '0 auto',
     marginBottom: 15,
   },
+  container: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    // justifyContent: 'center',
+    maxWidth: 2000,
+  },
   card: {
-    margin: '0 5px',
+    margin: '15px 5px',
     maxHeight: 325,
     minWidth: 275,
     textAlign: 'center',
     textDecoration: 'none',
-  },
-  container: {
-    display: 'flex',
-    marginTop: 20,
-    maxWidth: 2000,
-    overflowX: 'scroll',
   },
   title: {
     marginBottom: 16,

--- a/src/components/List/ListItems.js
+++ b/src/components/List/ListItems.js
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 
 // MATERIAL-UI DEPENDENCIES
 import { withStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
-import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
 // INTERNAL DEPENDENCIES
@@ -15,22 +15,22 @@ import preload from '../../services/db.json';
 
 // LOCAL VARIABLES
 const styles = {
+  button: {
+    margin: '0 auto',
+    marginBottom: 15,
+  },
   card: {
     margin: '0 5px',
-    minWidth: 275,
     maxHeight: 325,
-    textAlign: 'center'
+    minWidth: 275,
+    textAlign: 'center',
+    textDecoration: 'none',
   },
   container: {
     display: 'flex',
     marginTop: 20,
     maxWidth: 2000,
     overflowX: 'scroll',
-  },
-  bullet: {
-    display: 'inline-block',
-    margin: '0 2px',
-    transform: 'scale(0.8)',
   },
   title: {
     marginBottom: 16,
@@ -39,6 +39,10 @@ const styles = {
   pos: {
     marginBottom: 12,
   },
+  thumbnail: {
+    width: 227,
+    height: 170,
+  }
 };
 
 // COMPONENT DEFINITION
@@ -49,14 +53,16 @@ const ListItems = (props) => {
       {preload.games.map(game => (
         <Card
           className={classes.card}
-          key={game.name}
+          component="a"
           game={game}
+          href={game.url}
+          key={game.name}
         >
           <CardContent>
             <img
               alt={game.name}
+              className={classes.thumbnail}
               src={game.backgroundImageURL}
-              style={{ width: '100%' }}
             />
             <Typography variant="headline" component="h2" style={{ fontWeight: 700 }}>
               {/* To prevent titles from using two lines, only allow 16 characters followed by ... */}
@@ -65,9 +71,10 @@ const ListItems = (props) => {
           </CardContent>
           <CardActions>
             <Button
-              component="a"
-              href={game.url}
+              className={classes.button}
+              color="primary"
               size="small"
+              variant="raised"
             >
               Downloads
             </Button>

--- a/src/components/Navbar/NavTabs.js
+++ b/src/components/Navbar/NavTabs.js
@@ -1,5 +1,6 @@
 // EXTERNAL DEPENDENCIES
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types';
 
 // MATERIAL-UI DEPENDENCIES
@@ -30,9 +31,13 @@ const styles = theme => ({
 
 // COMPONENT DEFINITION
 class NavTabs extends Component {
-    state = {
-        value: 0,
-    };
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            value: 1,
+        };
+    }
 
     handleChange = (event, value) => {
         this.setState({ value });
@@ -46,9 +51,9 @@ class NavTabs extends Component {
             <div className={classes.root}>
                 <AppBar position="static" elevation={0}>
                     <Tabs value={value} onChange={this.handleChange} centered>
-                        <Tab label="Library" href="/library" />
-                        <Tab label="Home" href="/" />
-                        <Tab label="Requests" href="/requests" />
+                        <Tab label="Library" component={Link} to="/library" centerRipple />
+                        <Tab label="Home" component={Link} to="/" centerRipple />
+                        <Tab label="Requests" component={Link} to="/requests" centerRipple />
                     </Tabs>
                 </AppBar>
             </div>

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -5,15 +5,24 @@ import React, { Component } from 'react';
 import ListItems from '../components/List/ListItems';
 
 // LOCAL VARIABLES
-const wrapper = {
-  display: 'grid',
+const styles = {
+  display: 'flex',
+  flexDirection: 'column',
+  marginLeft: 45,
+}
+
+const titleStyles = {
+  fontWeight: 700,
+  marginTop: 45,
 }
 
 // COMPONENT DEFINITION
 class Dashboard extends Component {
   render() {
+    const title = "Video Game Piano Tutorials"
     return (
-      <div style={wrapper}>
+      <div style={styles}>
+        <p style={titleStyles}> {title.toUpperCase()}</p>
         <ListItems />
       </div>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,6 +2951,10 @@ es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-symbol "~3.1.1"
     next-tick "1"
 
+es6-error@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
+
 es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
@@ -4133,7 +4137,7 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^2.5.4:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
@@ -5732,7 +5736,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.5, lodash-es@^4.2.1:
+lodash-es@^4.17.10, lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
 
@@ -7761,6 +7765,19 @@ reduce-function-call@^1.0.1:
 redux-devtools-extension@^2.13.2:
   version "2.13.5"
   resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.5.tgz#3ff34f7227acfeef3964194f5f7fc2765e5c5a39"
+
+redux-form@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-7.4.2.tgz#d6061088fb682eb9fc5fb9749bd8b102f03154b0"
+  dependencies:
+    es6-error "^4.1.1"
+    hoist-non-react-statics "^2.5.4"
+    invariant "^2.2.4"
+    is-promise "^2.1.0"
+    lodash "^4.17.10"
+    lodash-es "^4.17.10"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
 
 redux@^3.7.2:
   version "3.7.2"


### PR DESCRIPTION
# The Issue :warning:
- The dashboard thumbnails' Downloads button had too small of a hit zone

# The Fix :wrench:
- Clicking anywhere on the thumbnail will lead to the tutorial page

Update:
- Fixes Navbar indicator issue
- Displays dashboard thumbnails as grid (via flexbox)

![2018-08-09-nav and dash grid](https://user-images.githubusercontent.com/24509848/43938369-dadc4856-9c28-11e8-93c0-d2772b44a2c5.gif)

