### PR TITLE
fix: fix mobile widths for titles and video player

### DIFF
--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -14,12 +14,13 @@ const styles = theme => ({
 	root: {
 		backgroundColor: theme.palette.background.paper,
 		margin: '0 auto',
-		width: '60%',
+		width: '100%'
 	},
 });
 
 const listItemStyles = {
-	color: 'red',
+	// textAlign: 'center',
+	fontSize: 20
 };
 
 // COMPONENT DEFINITION
@@ -53,61 +54,61 @@ const Library = (props) => {
 					<ListItemText style={listItemStyles} primary="1001 Spikes" />
 				</ListItem>
 				<ListItem button divider component="a" href="/beyond-two-souls" onClick={() => trackEvent(('beyond-two-souls'))}>
-					<ListItemText primary="Beyond Two Souls" />
-				</ListItem>
-				<ListItem button divider component="a" href="/brothers" onClick={() => trackEvent(('brothers'))}>
-					<ListItemText primary="Brothers: A Tale of Two Sons" />
-				</ListItem>
-				<ListItem button divider component="a" href="/catherine" onClick={() => trackEvent(('catherine'))}>
-					<ListItemText primary="Catherine" />
-				</ListItem>
-				<ListItem button divider component="a" href="/chroma" onClick={() => trackEvent(('chroma'))}>
-					<ListItemText primary="Chroma" />
-				</ListItem>
-				<ListItem button divider component="a" href="/grand-theft-auto" onClick={() => trackEvent(('grand-theft-auto'))}>
-					<ListItemText primary="Grand Theft Auto" />
-				</ListItem>
-				<ListItem button divider component="a" href="/infamous" onClick={() => trackEvent(('infamous'))}>
-					<ListItemText primary="inFAMOUS" />
-				</ListItem>
-				<ListItem button divider component="a" href="/life-is-strange" onClick={() => trackEvent(('life-is-strange'))}>
-					<ListItemText primary="Life Is Strange" />
-				</ListItem>
-				<ListItem button divider component="a" href="/minecraft" onClick={() => trackEvent(('minecraft'))}>
-					<ListItemText primary="Minecraft" />
-				</ListItem>
-				<ListItem button divider component="a" href="/nba-street" onClick={() => trackEvent(('nba-street'))}>
-					<ListItemText primary="NBA Street" />
-				</ListItem>
-				<ListItem button divider component="a" href="/playstation-commercials" onClick={() => trackEvent(('playstation-commercials'))}>
-					<ListItemText primary="Playstation Commercials" />
-				</ListItem>
-				<ListItem button divider component="a" href="/pokemon" onClick={() => trackEvent(('pokemon'))}>
-					<ListItemText primary="Pokemon" />
-				</ListItem>
-				<ListItem button divider component="a" href="/resident-evil" onClick={() => trackEvent(('resident-evil'))}>
-					<ListItemText primary="Resident Evil" />
-				</ListItem>
-				<ListItem button divider component="a" href="/the-last-of-us" onClick={() => trackEvent(('the-last-of-us'))}>
-					<ListItemText primary="The Last of Us" />
-				</ListItem>
-				<ListItem button divider component="a" href="/the-walking-dead-game" onClick={() => trackEvent(('the-walking-dead-game'))}>
-					<ListItemText primary="The Walking Dead Game" />
-				</ListItem>
-				<ListItem button divider component="a" href="/thomas-was-alone" onClick={() => trackEvent(('chrothomas-was-alonema'))}>
-					<ListItemText primary="Thomas Was Alone" />
-				</ListItem>
-				<ListItem button divider component="a" href="/transistor" onClick={() => trackEvent(('transistor'))}>
-					<ListItemText primary="Transistor" />
-				</ListItem>
-				<ListItem button divider component="a" href="/uncharted" onClick={() => trackEvent(('uncharted'))}>
-					<ListItemText primary="Uncharted" />
-				</ListItem>
-				<ListItem button divider component="a" href="/mashups" onClick={() => trackEvent(('mashups'))}>
-					<ListItemText primary="Video Game Piano Mashups" />
+					<ListItemText style={listItemStyles} primary="Beyond Two Souls" />
 				</ListItem>
 				<ListItem button divider component="a" href="/bobs-burgers" onClick={() => trackEvent(('bobs-burgers'))}>
-					<ListItemText primary="Bob's Burgers" />
+					<ListItemText style={listItemStyles} primary="Bob's Burgers" />
+				</ListItem>
+				<ListItem button divider component="a" href="/brothers" onClick={() => trackEvent(('brothers'))}>
+					<ListItemText style={listItemStyles} primary="Brothers: A Tale of Two Sons" />
+				</ListItem>
+				<ListItem button divider component="a" href="/catherine" onClick={() => trackEvent(('catherine'))}>
+					<ListItemText style={listItemStyles} primary="Catherine" />
+				</ListItem>
+				<ListItem button divider component="a" href="/chroma" onClick={() => trackEvent(('chroma'))}>
+					<ListItemText style={listItemStyles} primary="Chroma" />
+				</ListItem>
+				<ListItem button divider component="a" href="/grand-theft-auto" onClick={() => trackEvent(('grand-theft-auto'))}>
+					<ListItemText style={listItemStyles} primary="Grand Theft Auto" />
+				</ListItem>
+				<ListItem button divider component="a" href="/infamous" onClick={() => trackEvent(('infamous'))}>
+					<ListItemText style={listItemStyles} primary="inFAMOUS" />
+				</ListItem>
+				<ListItem button divider component="a" href="/life-is-strange" onClick={() => trackEvent(('life-is-strange'))}>
+					<ListItemText style={listItemStyles} primary="Life Is Strange" />
+				</ListItem>
+				<ListItem button divider component="a" href="/minecraft" onClick={() => trackEvent(('minecraft'))}>
+					<ListItemText style={listItemStyles} primary="Minecraft" />
+				</ListItem>
+				<ListItem button divider component="a" href="/nba-street" onClick={() => trackEvent(('nba-street'))}>
+					<ListItemText style={listItemStyles} primary="NBA Street" />
+				</ListItem>
+				<ListItem button divider component="a" href="/playstation-commercials" onClick={() => trackEvent(('playstation-commercials'))}>
+					<ListItemText style={listItemStyles} primary="Playstation Commercials" />
+				</ListItem>
+				<ListItem button divider component="a" href="/pokemon" onClick={() => trackEvent(('pokemon'))}>
+					<ListItemText style={listItemStyles} primary="Pokemon" />
+				</ListItem>
+				<ListItem button divider component="a" href="/resident-evil" onClick={() => trackEvent(('resident-evil'))}>
+					<ListItemText style={listItemStyles} primary="Resident Evil" />
+				</ListItem>
+				<ListItem button divider component="a" href="/the-last-of-us" onClick={() => trackEvent(('the-last-of-us'))}>
+					<ListItemText style={listItemStyles} primary="The Last of Us" />
+				</ListItem>
+				<ListItem button divider component="a" href="/the-walking-dead-game" onClick={() => trackEvent(('the-walking-dead-game'))}>
+					<ListItemText style={listItemStyles} primary="The Walking Dead Game" />
+				</ListItem>
+				<ListItem button divider component="a" href="/thomas-was-alone" onClick={() => trackEvent(('chrothomas-was-alonema'))}>
+					<ListItemText style={listItemStyles} primary="Thomas Was Alone" />
+				</ListItem>
+				<ListItem button divider component="a" href="/transistor" onClick={() => trackEvent(('transistor'))}>
+					<ListItemText style={listItemStyles} primary="Transistor" />
+				</ListItem>
+				<ListItem button divider component="a" href="/uncharted" onClick={() => trackEvent(('uncharted'))}>
+					<ListItemText style={listItemStyles} primary="Uncharted" />
+				</ListItem>
+				<ListItem button divider component="a" href="/mashups" onClick={() => trackEvent(('mashups'))}>
+					<ListItemText style={listItemStyles} primary="Video Game Piano Mashups" />
 				</ListItem>
 			</List>
 		</div>

--- a/src/components/library/tutorials-info/1001Spikes/index.js
+++ b/src/components/library/tutorials-info/1001Spikes/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/BeyondTwoSouls/index.js
+++ b/src/components/library/tutorials-info/BeyondTwoSouls/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/BobsBurgers/index.js
+++ b/src/components/library/tutorials-info/BobsBurgers/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/Brothers/index.js
+++ b/src/components/library/tutorials-info/Brothers/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/Catherine/index.js
+++ b/src/components/library/tutorials-info/Catherine/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/Chroma/index.js
+++ b/src/components/library/tutorials-info/Chroma/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/GrandTheftAuto/index.js
+++ b/src/components/library/tutorials-info/GrandTheftAuto/index.js
@@ -14,7 +14,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/Infamous/index.js
+++ b/src/components/library/tutorials-info/Infamous/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/LifeIsStrange/index.js
+++ b/src/components/library/tutorials-info/LifeIsStrange/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/Mashups/index.js
+++ b/src/components/library/tutorials-info/Mashups/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/Minecraft/index.js
+++ b/src/components/library/tutorials-info/Minecraft/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/NbaStreet/index.js
+++ b/src/components/library/tutorials-info/NbaStreet/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/PlaystationCommercials/index.js
+++ b/src/components/library/tutorials-info/PlaystationCommercials/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/Pokemon/index.js
+++ b/src/components/library/tutorials-info/Pokemon/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/ResidentEvil/index.js
+++ b/src/components/library/tutorials-info/ResidentEvil/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/TheLastOfUs/index.js
+++ b/src/components/library/tutorials-info/TheLastOfUs/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/TheWalkingDeadGame/index.js
+++ b/src/components/library/tutorials-info/TheWalkingDeadGame/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/ThomasWasAlone/index.js
+++ b/src/components/library/tutorials-info/ThomasWasAlone/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/Transistor/index.js
+++ b/src/components/library/tutorials-info/Transistor/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/library/tutorials-info/Uncharted/index.js
+++ b/src/components/library/tutorials-info/Uncharted/index.js
@@ -13,7 +13,6 @@ const styles = theme => ({
 	root: {
 		width: '100%',
 		margin: '0 auto',
-		maxWidth: '90%',
 		backgroundColor: theme.palette.background.paper,
 	},
 });

--- a/src/components/shared/tutorial/tutorial-card.jsx
+++ b/src/components/shared/tutorial/tutorial-card.jsx
@@ -17,10 +17,8 @@ const styles = theme => ({
 		fontSize: '1.5em',
 		fontWeight: 700,
 		margin: '0 auto',
-		minWidth: 450,
 		paddingBottom: theme.spacing.unit * 2,
 		paddingTop: theme.spacing.unit * 2,
-		width: '50%',
 	},
 });
 

--- a/src/components/shared/tutorial/tutorial-wrapper.jsx
+++ b/src/components/shared/tutorial/tutorial-wrapper.jsx
@@ -18,10 +18,9 @@ const styles = theme => ({
 		fontSize: '1.5em',
 		fontWeight: 700,
 		margin: '0 auto',
-		minWidth: 450,
+		maxWidth: 700,
 		paddingBottom: theme.spacing.unit * 2,
-		paddingTop: theme.spacing.unit * 2,
-		width: '50%',
+		paddingTop: theme.spacing.unit * 2
 	},
 });
 

--- a/src/components/shared/tutorial/video-player.jsx
+++ b/src/components/shared/tutorial/video-player.jsx
@@ -23,7 +23,6 @@ const VideoPlayer = (props) => {
 				height="360"
 				onClick={() => trackEvent(props.videoUrl)}
 				src={url}
-				style={{ margin: '0 auto' }}
 				title="Game Title"
 				width="100%"
 			>


### PR DESCRIPTION
BEFORE|AFTER
----|----
<img width="1195" alt="Screen Shot 2019-12-26 at 11 30 02 AM" src="https://user-images.githubusercontent.com/24509848/71484666-2759ca00-27d3-11ea-96cb-9b108215bb43.png">|<img width="1195" alt="Screen Shot 2019-12-26 at 11 29 51 AM" src="https://user-images.githubusercontent.com/24509848/71484671-3476b900-27d3-11ea-8288-2b52f7093473.png">

BEFORE|AFTER
----|----
<img width="1186" alt="Screen Shot 2019-12-26 at 11 30 09 AM" src="https://user-images.githubusercontent.com/24509848/71484677-3fc9e480-27d3-11ea-8f0f-d78407360a9c.png">|<img width="1187" alt="Screen Shot 2019-12-26 at 11 29 40 AM" src="https://user-images.githubusercontent.com/24509848/71484684-48bab600-27d3-11ea-8675-a435ae5b93ce.png">



